### PR TITLE
A version that doesn't need an Application ID

### DIFF
--- a/Userreport-survey-client/app/src/main/AndroidManifest.xml
+++ b/Userreport-survey-client/app/src/main/AndroidManifest.xml
@@ -18,9 +18,5 @@
             </intent-filter>
         </activity>
         <activity android:name=".StubActivity" />
-
-        <meta-data
-            android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3009546543862516~5494898247" />
     </application>
 </manifest>

--- a/Userreport-survey/userreport/build.gradle
+++ b/Userreport-survey/userreport/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.android.gms:play-services-ads:21.5.0'
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.android.volley:volley:1.2.0'
     implementation 'androidx.browser:browser:1.2.0'
 }

--- a/readme.md
+++ b/readme.md
@@ -33,24 +33,7 @@ dependencies {
 ```
 -keep class com.audienceproject.userreport.models.** { *; }
 ```
-3. SDK relies on **AAID**. In order to get it app needs **AdMob**.
-
-
-###### Admob
-Add your [AdMob App ID](https://support.google.com/admob/answer/7356431) to your app's `AndroidManifest.xml` file by adding a `<meta-data>` tag with name `com.google.android.gms.ads.APPLICATION_ID`, as shown below.
-
-You can find your **App ID** in the AdMob UI. For `android:value` insert your own AdMob App ID in quotes, as shown below.
-
-```
-<manifest>
-    <application>
-        <!-- Sample AdMob App ID: ca-app-pub-3940256099942544~3347511713 -->
-        <meta-data
-            android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy"/>
-    </application>
-</manifest>
-```
+3. SDK relies on **AAID**. It doesn't use the other parts of Google Mobile Ads and therefore does not need **AdMob**.
 
 ## Usage
 


### PR DESCRIPTION
Changed the play-services-ads dependency to play-services-ads-identifier, since only the identifier is used. This allows the users to use the library without a Google Mobile Ads Application ID.